### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for multicluster-global-hub-operator-bundle-globalhub-1-5

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -25,7 +25,8 @@ LABEL com.redhat.component="multicluster-global-hub-operator-bundle-container"
 LABEL com.redhat.delivery.operator.bundle=true
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-operator-bundle"
+LABEL name="multicluster-globalhub/multicluster-globalhub-operator-bundle"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.5::el9"
 LABEL version="release-1.5"
 LABEL summary="multicluster global hub operator bundle"
 LABEL io.openshift.expose-services=""


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
