### PR TITLE
fix: update ACM documentation version from 2.9 to 2.15

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -255,7 +255,7 @@ spec:
     ```
     ## Documentation
     For documentation about installing and using the Multicluster GlobalHub Operator with Red Hat Advanced Cluster Management for
-    Kubernetes, see [Multicluser GlobalHub Documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html-single/multicluster_global_hub/index#doc-wrapper) in the Red Hat Advanced Cluster Management
+    Kubernetes, see [Multicluser GlobalHub Documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.15/html-single/multicluster_global_hub/index#doc-wrapper) in the Red Hat Advanced Cluster Management
     documentation.
 
     ## Support & Troubleshooting


### PR DESCRIPTION
This PR updates the documentation link in the ClusterServiceVersion to reference ACM 2.15 instead of 2.9 for the Multicluster Global Hub documentation.

The documentation URL was pointing to version 2.9, but it should be 2.15 to match the current release.

### Changes
- Updated the documentation URL in `bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml`
- Changed version from 2.9 to 2.15 in the ACM documentation link