### PR TITLE
Update release-1.7 bundle configuration

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.5.0 <1.7.0'
+    olm.skipRange: '>=1.6.0 <1.7.0'
     operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
       "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"},
       "spec": {}}'

--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -58,5 +58,5 @@ sed -i \
 	"${csv_file}"
 
 sed -i -e "s|multicluster-global-hub-operator\\.v|multicluster-global-hub-operator-rh\\.v|g" "${csv_file}"
-sed -i -e "s|1.6.0-dev|1.6.0|g" "${csv_file}"
+sed -i -e "s|1.7.0-dev|1.7.0|g" "${csv_file}"
 sed -i -e "s|multicluster-global-hub-operator|multicluster-global-hub-operator-rh|g" "metadata/annotations.yaml"


### PR DESCRIPTION
Update release-1.7 bundle configuration

## Changes

- Update imageDigestMirrorSet to use `globalhub-1-7`
- Rename and update pull-request pipeline for `globalhub-1-7`
- Rename and update push pipeline for `globalhub-1-7`
- Update bundle image labels to `1.7`
- Update konflux-patch.sh image references to `globalhub-1-7`

## Version Mapping

- **ACM**: release-2.16
- **Global Hub**: release-1.7
- **Bundle tag**: globalhub-1-7
- **Previous bundle**: release-1.6