### PR TITLE
Add build-nudge-files annotation to pull-request pipeline

### DIFF
--- a/.tekton/multicluster-global-hub-operator-bundle-globalhub-1-7-pull-request.yaml
+++ b/.tekton/multicluster-global-hub-operator-bundle-globalhub-1-7-pull-request.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: ".*-current.json"
     build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub-operator-bundle?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'


### PR DESCRIPTION
## Changes

Add `build.appstudio.openshift.io/build-nudge-files: ".*-current.json"` annotation to the pull-request pipeline.

## Purpose

This annotation enables automatic builds when `catalog-template-current.json` is updated, ensuring the bundle is rebuilt when catalog configuration changes.

## Files Modified

- `.tekton/multicluster-global-hub-operator-bundle-globalhub-1-7-pull-request.yaml`

## Reference

This annotation should be present in all release branch pull-request pipelines to enable proper catalog update automation.