### PR TITLE
Update release-1.7 bundle configuration

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2025-08-27T07:10:21Z"
+    createdAt: "2025-11-13T09:03:15Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -255,7 +255,7 @@ spec:
     ```
     ## Documentation
     For documentation about installing and using the Multicluster GlobalHub Operator with Red Hat Advanced Cluster Management for
-    Kubernetes, see [Multicluser GlobalHub Documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html-single/multicluster_global_hub/index#doc-wrapper) in the Red Hat Advanced Cluster Management
+    Kubernetes, see [Multicluser GlobalHub Documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.16/html-single/multicluster_global_hub/index#doc-wrapper) in the Red Hat Advanced Cluster Management
     documentation.
 
     ## Support & Troubleshooting

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,8 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: multicluster-global-hub-operator
-  operators.operatorframework.io.bundle.channels.v1: release-1.6
-  operators.operatorframework.io.bundle.channel.default.v1: release-1.6
+  operators.operatorframework.io.bundle.channels.v1: release-1.7
+  operators.operatorframework.io.bundle.channel.default.v1: release-1.7
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4


### PR DESCRIPTION
Update release-1.7 bundle configuration

## Changes

- Copy latest operator bundle from multicluster-global-hub (manifests, metadata, tests)
- Update imageDigestMirrorSet to use `globalhub-1-7`
- Rename and update pull-request pipeline for `globalhub-1-7`
- Rename and update push pipeline for `globalhub-1-7`
- Update bundle image labels to `1.7`
- Update CSV skipRange to `>=1.6.0 <1.7.0`
- Update konflux-patch.sh image references to `globalhub-1-7`
- Update konflux-patch.sh version replacement to `1.7.0`

## Version Mapping

- **ACM**: release-2.16
- **Global Hub**: release-1.7
- **Bundle tag**: globalhub-1-7
- **Previous bundle**: release-1.6