### PR TITLE
Update release-1.7 bundle configuration

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2025-11-13T09:03:15Z"
+    createdAt: "2025-11-18T04:45:26Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"


### PR DESCRIPTION
Update release-1.7 bundle configuration

## Changes

- Copy latest operator bundle from multicluster-global-hub (manifests, metadata, tests)
- Update imageDigestMirrorSet to use `globalhub-1-7`
- Rename and update pull-request pipeline for `globalhub-1-7`
- Rename and update push pipeline for `globalhub-1-7`
- Update bundle image labels to `1.7`
- Update CSV skipRange to `>=1.6.0 <1.7.0`
- Update konflux-patch.sh image references to `globalhub-1-7`
- Update konflux-patch.sh version replacement to `1.7.0`

## Version Mapping

- **ACM**: release-2.16
- **Global Hub**: release-1.7
- **Bundle tag**: globalhub-1-7
- **Previous bundle**: release-1.6