### PR TITLE
Upgrade controller-gen version

### DIFF
--- a/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
+++ b/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   name: managedclustermigrations.global-hub.open-cluster-management.io
 spec:

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubagents.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubagents.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   name: multiclusterglobalhubagents.operator.open-cluster-management.io
 spec:

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   name: multiclusterglobalhubs.operator.open-cluster-management.io
 spec:


### PR DESCRIPTION
## Summary
- Upgrade controller-gen version from v0.16.0 to v0.18.0 in CRD manifests

## Changes
- Updated `global-hub.open-cluster-management.io_managedclustermigrations.yaml`
- Updated `operator.open-cluster-management.io_multiclusterglobalhubagents.yaml`
- Updated `operator.open-cluster-management.io_multiclusterglobalhubs.yaml`

This change aligns with:
- PR #507 to release-1.7 branch
- PR #512 to release-1.6 branch
- PR #513 to release-1.5 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)