### PR TITLE
Add dataimages RBAC permission to operator CSV

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2025-12-29T00:53:55Z"
+    createdAt: "2026-01-19T08:54:20Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -838,6 +838,7 @@ spec:
           resources:
           - baremetalhosts
           - baremetalhosts/status
+          - dataimages
           - firmwareschemas
           - firmwareschemas/status
           - hostfirmwarecomponents


### PR DESCRIPTION
Add dataimages resource to the metal3.io API group permissions in the ClusterServiceVersion. This allows the operator to manage BMO dataimage resources for bare metal cluster provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: daliu@redhat.com