### PR TITLE
chore(KONFLUX-6210): Update CPE label and naming for release 1.7

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -14,19 +14,20 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multicluster-global-hub-operator-rh
-LABEL operators.operatorframework.io.bundle.channels.v1=release-1.6
-LABEL operators.operatorframework.io.bundle.channel.default.v1=release-1.6
+LABEL operators.operatorframework.io.bundle.channels.v1=release-1.7
+LABEL operators.operatorframework.io.bundle.channel.default.v1=release-1.7
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
 # Red Hat annotations.
-LABEL com.redhat.component="multicluster-global-hub-operator-bundle-container"
+LABEL com.redhat.component="multicluster-globalhub-operator-bundle-container"
 LABEL com.redhat.delivery.operator.bundle=true
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.7::el9"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-operator-bundle"
-LABEL version="release-1.6"
+LABEL name="multicluster-globalhub/multicluster-globalhub-operator-bundle"
+LABEL version="release-1.7"
 LABEL summary="multicluster global hub operator bundle"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
## Summary
- Add CPE label `cpe:/a:redhat:multicluster_globalhub:1.7::el9` for KONFLUX-6210 compliance
- Update component name to `multicluster-globalhub-operator-bundle-container`
- Update name label to `multicluster-globalhub/multicluster-globalhub-operator-bundle`
- Update version from `release-1.6` to `release-1.7`
- Update channel labels from `release-1.6` to `release-1.7`

## Context
This change addresses KONFLUX-6210, which requires Clair to have access to name and CPE labels for VEX statement lookups.

See also: release-engineering/rhtap-ec-policy#149

🤖 Generated with [Claude Code](https://claude.com/claude-code)