### PR TITLE
:sparkles: Bump to 1.5.3

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -70,7 +70,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.5.2
+  name: multicluster-global-hub-operator.v1.5.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1140,5 +1140,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.5.1
-  version: 1.5.2
+  replaces: multicluster-global-hub-operator.v1.5.2
+  version: 1.5.3


### PR DESCRIPTION
Bump version to 1.5.3 for z-stream release.

## Changes
- Updated version from 1.5.2 to 1.5.3
- Updated replaces field to reference previous version

## Related
- Part of z-stream release v1.5.3
