### PR TITLE
:sparkles: Bump to 1.4.4

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -70,7 +70,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.4.3
+  name: multicluster-global-hub-operator.v1.4.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1016,5 +1016,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.4.2
-  version: 1.4.3
+  replaces: multicluster-global-hub-operator.v1.4.3
+  version: 1.4.4


### PR DESCRIPTION
Bump version to 1.4.4 for z-stream release.

## Changes
- Updated version from 1.4.3 to 1.4.4
- Updated replaces field to reference previous version

## Related
- Part of z-stream release v1.4.4
