### PR TITLE
Add GitHub workflow to auto-label Konflux bot PRs

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,17 @@
+name: Label PRs by User
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  add_labels:
+    if: ${{ github.event.pull_request.user.login == 'red-hat-konflux[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: add labels
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: |
+            lgtm
+            approved


### PR DESCRIPTION
## Summary
- Add `.github/workflows/labels.yml` from release-1.7
- Automatically labels PRs created by red-hat-konflux[bot] with `lgtm` and `approved` labels

## Test plan
- [ ] Verify workflow file is correctly added
- [ ] Verify workflow triggers on Konflux bot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)