### PR TITLE
Update release-1.8 bundle configuration

### DIFF
--- a/.tekton/images_digest_mirror_set.yaml
+++ b/.tekton/images_digest_mirror_set.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   imageDigestMirrors:
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-agent-globalhub-1-7
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-agent-globalhub-1-8
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-agent-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-1-7
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-1-8
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-manager-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-1-7
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-1-8
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator
     - mirrors:
         - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-6

--- a/.tekton/multicluster-global-hub-operator-bundle-globalhub-1-8-pull-request.yaml
+++ b/.tekton/multicluster-global-hub-operator-bundle-globalhub-1-8-pull-request.yaml
@@ -5,17 +5,18 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: ".*-current.json"
     build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub-operator-bundle?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.7"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-1.8"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-globalhub-1-7
-    appstudio.openshift.io/component: multicluster-global-hub-operator-bundle-globalhub-1-7
+    appstudio.openshift.io/application: release-globalhub-1-8
+    appstudio.openshift.io/component: multicluster-global-hub-operator-bundle-globalhub-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: multicluster-global-hub-operator-bundle-globalhub-1-7-on-push
+  name: multicluster-global-hub-operator-bundle-globalhub-1-8-on-pull-request
   namespace: acm-multicluster-glo-tenant
 spec:
   params:
@@ -24,7 +25,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-bundle-globalhub-1-7:{{revision}}
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-bundle-globalhub-1-8:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: dockerfile
     value: Containerfile.bundle
   - name: path-context
@@ -33,19 +36,6 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
-  - name: send-slack-notification
-    value: "true"
-  - name: konflux-application-name
-    value: "release-globalhub-1-7"
-  - name: slack-webhook-url-secret-name
-    # See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
-    value: "slack-notify-webhook"
-  - name: slack-webhook-url-secret-key
-    value: "slack-webhook-url"
-  - name: slack-group-id
-    # Will mention the user in the slack message when the pipeline run failed; this is not required.
-    # Please make sure replace the value with component owner's slack member id.
-    value: "S09JCE3DF9N" 
   pipelineRef:
     resolver: git
     params:
@@ -56,7 +46,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-oci-ta.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-multicluster-global-hub-operator-bundle-globalhub-1-7
+    serviceAccountName: build-pipeline-multicluster-global-hub-operator-bundle-globalhub-1-8
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/multicluster-global-hub-operator-bundle-globalhub-1-8-push.yaml
+++ b/.tekton/multicluster-global-hub-operator-bundle-globalhub-1-8-push.yaml
@@ -5,18 +5,17 @@ metadata:
     build.appstudio.openshift.io/build-nudge-files: ".*-current.json"
     build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub-operator-bundle?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.7"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-1.8"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-globalhub-1-7
-    appstudio.openshift.io/component: multicluster-global-hub-operator-bundle-globalhub-1-7
+    appstudio.openshift.io/application: release-globalhub-1-8
+    appstudio.openshift.io/component: multicluster-global-hub-operator-bundle-globalhub-1-8
     pipelines.appstudio.openshift.io/type: build
-  name: multicluster-global-hub-operator-bundle-globalhub-1-7-on-pull-request
+  name: multicluster-global-hub-operator-bundle-globalhub-1-8-on-push
   namespace: acm-multicluster-glo-tenant
 spec:
   params:
@@ -25,9 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-bundle-globalhub-1-7:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-bundle-globalhub-1-8:{{revision}}
   - name: dockerfile
     value: Containerfile.bundle
   - name: path-context
@@ -36,6 +33,19 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-globalhub-1-8"
+  - name: slack-webhook-url-secret-name
+    # See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
+    value: "slack-notify-webhook"
+  - name: slack-webhook-url-secret-key
+    value: "slack-webhook-url"
+  - name: slack-group-id
+    # Will mention the user in the slack message when the pipeline run failed; this is not required.
+    # Please make sure replace the value with component owner's slack member id.
+    value: "S09JCE3DF9N" 
   pipelineRef:
     resolver: git
     params:
@@ -46,7 +56,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-oci-ta.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-multicluster-global-hub-operator-bundle-globalhub-1-7
+    serviceAccountName: build-pipeline-multicluster-global-hub-operator-bundle-globalhub-1-8
   workspaces:
   - name: git-auth
     secret:

--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2026-01-21T06:18:42Z"
+    createdAt: "2026-03-12T08:36:41Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -53,7 +53,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.6.0 <1.7.0'
+    olm.skipRange: '>=1.7.0 <1.8.0'
     operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
       "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"},
       "spec": {}}'
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.7.0-dev
+  name: multicluster-global-hub-operator.v1.8.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -255,7 +255,7 @@ spec:
     ```
     ## Documentation
     For documentation about installing and using the Multicluster GlobalHub Operator with Red Hat Advanced Cluster Management for
-    Kubernetes, see [Multicluser GlobalHub Documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.16/html-single/multicluster_global_hub/index#doc-wrapper) in the Red Hat Advanced Cluster Management
+    Kubernetes, see [Multicluser GlobalHub Documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.17/html-single/multicluster_global_hub/index#doc-wrapper) in the Red Hat Advanced Cluster Management
     documentation.
 
     ## Support & Troubleshooting
@@ -1141,8 +1141,8 @@ spec:
   maintainers:
   - email: acm-contact@redhat.com
     name: acm-contact
-  maturity: release-1.7
+  maturity: release-1.8
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 1.7.0-dev
+  version: 1.8.0-dev

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,8 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: multicluster-global-hub-operator
-  operators.operatorframework.io.bundle.channels.v1: release-1.7
-  operators.operatorframework.io.bundle.channel.default.v1: release-1.7
+  operators.operatorframework.io.bundle.channels.v1: release-1.8
+  operators.operatorframework.io.bundle.channel.default.v1: release-1.8
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4

--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -2,19 +2,19 @@
 
 set -e
 
-export MULTICLUSTER_GLOBAL_HUB_AGENT_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-agent-globalhub-1-7@sha256:339184322fdecae3a67763b698eeca541553d3497f99520d9df8769bd6ed77b3
+export MULTICLUSTER_GLOBAL_HUB_AGENT_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-agent-globalhub-1-8@sha256:339184322fdecae3a67763b698eeca541553d3497f99520d9df8769bd6ed77b3
 export MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-agent-rhel9@${MULTICLUSTER_GLOBAL_HUB_AGENT_STAGE_IMAGE##*@}"
 
-export MULTICLUSTER_GLOBAL_HUB_MANAGER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-1-7@sha256:ceac6f165f74e6fc399914fae4c14ea8062e5322a7c4312ee9837bc67bbc1a38
+export MULTICLUSTER_GLOBAL_HUB_MANAGER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-1-8@sha256:ceac6f165f74e6fc399914fae4c14ea8062e5322a7c4312ee9837bc67bbc1a38
 export MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-manager-rhel9@${MULTICLUSTER_GLOBAL_HUB_MANAGER_STAGE_IMAGE##*@}"
 
-export MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-1-7@sha256:dc7f88f17f004bb0da88bb6e5603c7d345c6c56ae8da0654c3c451d04987c54e
+export MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-1-8@sha256:dc7f88f17f004bb0da88bb6e5603c7d345c6c56ae8da0654c3c451d04987c54e
 export MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@${MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE##*@}"
 
-export MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-7@sha256:2af3fd28b6b2b236d2f66f9808f2c369ae6a71b49db123cfffb03bc032896bbf
+export MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-8@sha256:2af3fd28b6b2b236d2f66f9808f2c369ae6a71b49db123cfffb03bc032896bbf
 export MULTICLUSTER_GLOBAL_HUB_GRAFANA_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-grafana-rhel9@${MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE##*@}"
 
-export MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-7@sha256:82855e975849e0e156bc940b01ca37858045bcbc3121b01b4eb22c0aaf8ac2dd
+export MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-8@sha256:82855e975849e0e156bc940b01ca37858045bcbc3121b01b4eb22c0aaf8ac2dd
 export MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9@${MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_STAGE_IMAGE##*@}"
 
 export MULTICLUSTER_GLOBAL_HUB_POSTGRESQL_IMAGE=registry.redhat.io/rhel9/postgresql-16@sha256:dc79eeb04f5ee2d396dc6c0d85ac7db45c0cb9cf1a8daba2b8226ae20aaab370
@@ -58,5 +58,5 @@ sed -i \
 	"${csv_file}"
 
 sed -i -e "s|multicluster-global-hub-operator\\.v|multicluster-global-hub-operator-rh\\.v|g" "${csv_file}"
-sed -i -e "s|1.7.0-dev|1.7.0|g" "${csv_file}"
+sed -i -e "s|1.8.0-dev|1.8.0|g" "${csv_file}"
 sed -i -e "s|multicluster-global-hub-operator|multicluster-global-hub-operator-rh|g" "metadata/annotations.yaml"


### PR DESCRIPTION
Update release-1.8 bundle configuration

## Changes

- Copy latest operator bundle from multicluster-global-hub (manifests, metadata, tests)
- Update imageDigestMirrorSet to use `globalhub-1-8`
- Rename and update pull-request pipeline for `globalhub-1-8`
- Rename and update push pipeline for `globalhub-1-8`
- Update bundle image labels to `1.8`
- Update CSV skipRange to `>=1.7.0 <1.8.0`
- Update konflux-patch.sh image references to `globalhub-1-8`
- Update konflux-patch.sh version replacement to `1.8.0`

## Version Mapping

- **ACM**: release-2.17
- **Global Hub**: release-1.8
- **Bundle tag**: globalhub-1-8
- **Previous bundle**: release-1.7