### PR TITLE
Configure Renovate to track PostgreSQL image updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,15 @@
   "addLabels": [
     "lgtm"
   ],
-  "branchPrefix": "konflux/component-updates/"
+  "branchPrefix": "konflux/component-updates/",
+  "regexManagers": [
+    {
+      "fileMatch": ["^konflux-patch\\.sh$"],
+      "matchStrings": [
+        "MULTICLUSTER_GLOBAL_HUB_POSTGRESQL_IMAGE=(?<depName>.*?)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ]
 }


### PR DESCRIPTION
ref: [ACM-30078](https://issues.redhat.com/browse/ACM-30078)
Add regex manager to renovate.json to automatically detect and update the PostgreSQL image digest in konflux-patch.sh. This enables automated dependency updates for the registry.redhat.io/rhel9/postgresql-16 image.