### PR TITLE
Fix Renovate configuration syntax errors (#773)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,12 +8,14 @@
     "lgtm"
   ],
   "branchPrefix": "konflux/component-updates/",
-  "regexManagers": [
+  "customManagers": [
     {
-      "fileMatch": ["^konflux-patch\\.sh$"],
+      "customType": "regex",
+      "fileMatch": ["(^|/)konflux-patch\\.sh$"],
       "matchStrings": [
-        "MULTICLUSTER_GLOBAL_HUB_POSTGRESQL_IMAGE=(?<depName>.*?)@(?<currentDigest>sha256:[a-f0-9]+)"
+        "export MULTICLUSTER_GLOBAL_HUB_POSTGRESQL_IMAGE=(?<depName>[^:@]+)@(?<currentDigest>sha256:[a-f0-9]+)"
       ],
+      "autoReplaceStringTemplate": "export MULTICLUSTER_GLOBAL_HUB_POSTGRESQL_IMAGE={{{depName}}}@{{{newDigest}}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     }


### PR DESCRIPTION
Updates the Renovate config to use the correct customManagers syntax with proper regex pattern matching for PostgreSQL image updates.

Changes:
- Switch from regexManagers to customManagers with customType
- Add 'export' keyword to regex pattern to match actual script format
- Add autoReplaceStringTemplate for proper update formatting
- Update fileMatch pattern for better path handling

Fixes #773