### PR TITLE
Remove baseBranchPatterns from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranchPatterns": [
-    "main",
-    "/^release-\\d+\\.\\d+/"
-  ],
   "addLabels": [
     "lgtm"
   ],


### PR DESCRIPTION
Removed baseBranchPatterns from configuration due to https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#potential-issues-with-basebranchpatterns-configuration