### PR TITLE
Bump to 1.6.2

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -70,7 +70,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.6.1
+  name: multicluster-global-hub-operator.v1.6.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1167,5 +1167,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.6.0
-  version: 1.6.1
+  replaces: multicluster-global-hub-operator.v1.6.1
+  version: 1.6.2


### PR DESCRIPTION
Bump version from 1.6.1 to 1.6.2 for z-stream release v1.6.2.