### PR TITLE
chore(deps): update Grafana image to 2.17.0

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -1279,7 +1279,7 @@ spec:
                 - name: RELATED_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT
                   value: quay.io/stolostron/multicluster-global-hub-agent:latest
                 - name: RELATED_IMAGE_GRAFANA
-                  value: quay.io/stolostron/grafana:2.12.0-SNAPSHOT-2024-09-03-21-11-25
+                  value: quay.io/stolostron/grafana:2.17.0-SNAPSHOT-2026-03-31-01-38-20
                 - name: RELATED_IMAGE_POSTGRESQL
                   value: quay.io/stolostron/postgresql-16:9.5-1732622748
                 - name: RELATED_IMAGE_POSTGRES_EXPORTER

--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -52,7 +52,7 @@ sed -i \
    -e "s|quay.io/stolostron/multicluster-global-hub-operator:latest|${MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE}|g" \
    -e "s|quay.io/stolostron/multicluster-global-hub-manager:latest|${MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE}|g" \
    -e "s|quay.io/stolostron/multicluster-global-hub-agent:latest|${MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE}|g" \
-   -e "s|quay.io/stolostron/grafana:2.12.0-SNAPSHOT-2024-09-03-21-11-25|${MULTICLUSTER_GLOBAL_HUB_GRAFANA_IMAGE}|g" \
+   -e "s|quay.io/stolostron/grafana:2.17.0-SNAPSHOT-2026-03-31-01-38-20|${MULTICLUSTER_GLOBAL_HUB_GRAFANA_IMAGE}|g" \
    -e "s|quay.io/prometheuscommunity/postgres-exporter:v0.15.0|${MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_IMAGE}|g" \
    -e "s|quay.io/stolostron/postgresql-16:9.5-1732622748|${MULTICLUSTER_GLOBAL_HUB_POSTGRESQL_IMAGE}|g" \
 	"${csv_file}"


### PR DESCRIPTION
## Summary

- Update Grafana image version from 2.12.0 to 2.17.0 snapshot
- Update bundle CSV and konflux-patch.sh to reference new image

## Changes

### Bundle Manifests
- `multicluster-global-hub-operator.clusterserviceversion.yaml`: Update RELATED_IMAGE_GRAFANA from `2.12.0-SNAPSHOT-2024-09-03-21-11-25` to `2.17.0-SNAPSHOT-2026-03-31-01-38-20`

### Konflux Patch Script
- `konflux-patch.sh`: Update sed pattern to match new Grafana image version

## Test plan

- [ ] Verify bundle manifests are valid
- [ ] Confirm konflux patch script correctly replaces image references
- [ ] Validate operator deployment with updated Grafana image

## Related Issues

Regular dependency update to keep Grafana current with latest builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: daliu@redhat.com