### PR TITLE
Update Grafana image to grafana-global-hub:12.4.0

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -1279,7 +1279,7 @@ spec:
                 - name: RELATED_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT
                   value: quay.io/stolostron/multicluster-global-hub-agent:latest
                 - name: RELATED_IMAGE_GRAFANA
-                  value: quay.io/stolostron/grafana:2.17.0-SNAPSHOT-2026-03-31-01-38-20
+                  value: quay.io/stolostron/grafana-global-hub:12.4.0
                 - name: RELATED_IMAGE_POSTGRESQL
                   value: quay.io/stolostron/postgresql-16:9.5-1732622748
                 - name: RELATED_IMAGE_POSTGRES_EXPORTER

--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -52,7 +52,7 @@ sed -i \
    -e "s|quay.io/stolostron/multicluster-global-hub-operator:latest|${MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE}|g" \
    -e "s|quay.io/stolostron/multicluster-global-hub-manager:latest|${MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE}|g" \
    -e "s|quay.io/stolostron/multicluster-global-hub-agent:latest|${MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE}|g" \
-   -e "s|quay.io/stolostron/grafana:2.17.0-SNAPSHOT-2026-03-31-01-38-20|${MULTICLUSTER_GLOBAL_HUB_GRAFANA_IMAGE}|g" \
+   -e "s|quay.io/stolostron/grafana-global-hub:12.4.0|${MULTICLUSTER_GLOBAL_HUB_GRAFANA_IMAGE}|g" \
    -e "s|quay.io/prometheuscommunity/postgres-exporter:v0.15.0|${MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_IMAGE}|g" \
    -e "s|quay.io/stolostron/postgresql-16:9.5-1732622748|${MULTICLUSTER_GLOBAL_HUB_POSTGRESQL_IMAGE}|g" \
 	"${csv_file}"


### PR DESCRIPTION
## Summary
- Update the Grafana image reference from `quay.io/stolostron/grafana:2.17.0-SNAPSHOT-2026-03-31-01-38-20` to `quay.io/stolostron/grafana-global-hub:12.4.0`
- Updated files:
  - `bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml`
  - `konflux-patch.sh`

## Test plan
- [ ] Verify bundle builds successfully
- [ ] Verify konflux-patch.sh correctly replaces the new image reference

🤖 Generated with [Claude Code](https://claude.ai/claude-code)