### PR TITLE
Update release-1.8 bundle configuration

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -14,8 +14,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multicluster-global-hub-operator-rh
-LABEL operators.operatorframework.io.bundle.channels.v1=release-1.7
-LABEL operators.operatorframework.io.bundle.channel.default.v1=release-1.7
+LABEL operators.operatorframework.io.bundle.channels.v1=release-1.8
+LABEL operators.operatorframework.io.bundle.channel.default.v1=release-1.8
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
@@ -23,11 +23,11 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-globalhub-operator-bundle-container"
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.7::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.8::el9"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-operator-bundle"
-LABEL version="release-1.7"
+LABEL version="release-1.8"
 LABEL summary="multicluster global hub operator bundle"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
Update release-1.8 bundle configuration

## Changes

- Copy latest operator bundle from multicluster-global-hub (manifests, metadata, tests)
- Update imageDigestMirrorSet to use `globalhub-1-8`
- Rename and update pull-request pipeline for `globalhub-1-8`
- Rename and update push pipeline for `globalhub-1-8`
- Update bundle image labels to `1.8`
- Update CSV skipRange to `>=1.7.0 <1.8.0`
- Update konflux-patch.sh image references to `globalhub-1-8`
- Update konflux-patch.sh version replacement to `1.8.0`
- Update Containerfile.bundle labels to `1.8`

## Version Mapping

- **ACM**: release-2.17
- **Global Hub**: release-1.8
- **Bundle tag**: globalhub-1-8
- **Previous bundle**: release-1.7