### PR TITLE
fix: update ManagedClusterMigration CRD with MigrationCondition type

### DIFF
--- a/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
+++ b/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
@@ -97,13 +97,21 @@ spec:
                 description: Conditions represents the latest available observations
                   of the current state
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: |-
+                    MigrationCondition extends metav1.Condition with LastUpdateTime to track
+                    when any field (reason, message, or status) was last updated. Unlike LastTransitionTime
+                    (which only updates on status changes per K8s convention), LastUpdateTime updates on
+                    any condition content change.
                   properties:
                     lastTransitionTime:
                       description: |-
                         lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the last time the condition was
+                        updated (reason, message, or status change).
                       format: date-time
                       type: string
                     message:


### PR DESCRIPTION
## Summary
- Add `lastUpdateTime` field to migration conditions CRD to support accurate stage timeout detection
- Update condition description to reflect the new `MigrationCondition` type
- Synced from stolostron/multicluster-global-hub#2362

## Test plan
- [ ] Verify bundle consistency check passes in the main repo PR after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)