### PR TITLE
fix: update name/cpe labels in Containerfile.bundle [multicluster-globalhub-1.3]

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -23,9 +23,10 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-global-hub-operator-bundle-container"
 LABEL com.redhat.delivery.operator.bundle=true
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.3::el9"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-operator-bundle"
+LABEL name="multicluster-globalhub/multicluster-globalhub-operator-bundle"
 LABEL version="release-1.3"
 LABEL summary="multicluster global hub operator bundle"
 LABEL io.openshift.expose-services=""


### PR DESCRIPTION
## Summary

Backport of KONFLUX-6210 label fixes from `release-1.4` to `release-1.3`.

The Konflux release pipeline `step-enforce-name-label` is failing for `multicluster-globalhub-operator-bundle-globalhub-1-3` because the `name` label uses the old format.

**Error:**
```
Component 'multicluster-globalhub-operator-bundle-globalhub-1-3' name label
('multicluster-global-hub/multicluster-global-hub-operator-bundle')
does not match expected name ('multicluster-globalhub/multicluster-globalhub-operator-bundle')
```

**Changes to `Containerfile.bundle`:**
| Label | Before | After |
|-------|--------|-------|
| `name` | `multicluster-global-hub/multicluster-global-hub-operator-bundle` | `multicluster-globalhub/multicluster-globalhub-operator-bundle` |
| `cpe` | _(missing)_ | `cpe:/a:redhat:multicluster_globalhub:1.3::el9` |

Same fix was applied to `release-1.4+` via KONFLUX-6210 but was never backported to `release-1.3`.

Made with [Cursor](https://cursor.com)