### PR TITLE
Bump to 1.8.0

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.8.0-dev
+  name: multicluster-global-hub-operator.v1.8.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1436,4 +1436,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 1.8.0-dev
+  replaces: multicluster-global-hub-operator.v1.7.0
+  version: 1.8.0

--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -1436,5 +1436,4 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.7.0
   version: 1.8.0


### PR DESCRIPTION
## Summary

1.8.0 GA version bump: `1.8.0-dev` → `1.8.0`.

Changes:
- `bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml`:
  - `name: multicluster-global-hub-operator.v1.8.0`
  - `version: 1.8.0`
  - `replaces: multicluster-global-hub-operator.v1.7.0`

> **Note**: If `v1.7.1` ships before 1.8.0 GA, update `replaces` to `multicluster-global-hub-operator.v1.7.1`.

Part of the 1.8.0 GA release — tracked in `pre-release/1.8.0-GA-version-bump.md`.

Made with [Cursor](https://cursor.com)