### PR TITLE
Bump to 1.7.1

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.7.1-dev
+  name: multicluster-global-hub-operator.v1.7.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1145,4 +1145,4 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 1.7.1-dev
+  version: 1.7.1


### PR DESCRIPTION
## Summary

Bump version from `1.7.1-dev` to `1.7.1` for z-stream release v1.7.1.

This is required before merging [stolostron/multicluster-global-hub-operator-catalog#423](https://github.com/stolostron/multicluster-global-hub-operator-catalog/pull/423) — the catalog bump PR cannot be merged until the bundle builds with a proper `v1.7.1` CSV (not `-dev`).

## Changes
- `bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml`: `v1.7.1-dev` → `v1.7.1`

Made with [Cursor](https://cursor.com)