### PR TITLE
Update GH 5.0 CPE and version labels in Containerfile.bundle

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -23,11 +23,11 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-globalhub-operator-bundle-container"
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.8::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.0::el9"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-operator-bundle"
-LABEL version="release-1.8"
+LABEL version="release-5.0"
 LABEL summary="multicluster global hub operator bundle"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
## Summary
Update image `cpe` and `version` labels from GH 1.8 to GH 5.0 on `release-5.0`.

## Why
Konflux stage publish (`stage-publish-globalhub-5-0`) failed `check-labels` / `enforce-cpe-label`:
built images had `cpe:/a:redhat:multicluster_globalhub:1.8::el9` but the 5.0 stage RPA requires `cpe:/a:redhat:multicluster_globalhub:5.0::el9`.

## Test plan
- [ ] Merge to `release-5.0` and wait for Konflux rebuild
- [ ] New snapshot passes stage publish `check-labels`