### PR TITLE
Update GH 5.0 konflux-patch digests to current snapshot

### DIFF
--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-export MULTICLUSTER_GLOBAL_HUB_AGENT_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-agent-globalhub-5-0@sha256:d2e7dd7ace301c93204683565e6d05c5b3d0d0af2df3ce997a88eb8491311b8b
+export MULTICLUSTER_GLOBAL_HUB_AGENT_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-agent-globalhub-5-0@sha256:04d334ae4d54e4f5833eee8b75ca8438b7eababde66fe469c376eaff96a2b2f2
 export MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-agent-rhel9@${MULTICLUSTER_GLOBAL_HUB_AGENT_STAGE_IMAGE##*@}"
 
-export MULTICLUSTER_GLOBAL_HUB_MANAGER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-5-0@sha256:9dfb9e0e539a24843b2248059f0f0258928e6092031c9efc734c99e842ca5c11
+export MULTICLUSTER_GLOBAL_HUB_MANAGER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-5-0@sha256:0872bfa0b0cfa5f707833707983e267f6225ac5baf13b507f2812ec3a7bf17e5
 export MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-manager-rhel9@${MULTICLUSTER_GLOBAL_HUB_MANAGER_STAGE_IMAGE##*@}"
 
-export MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-5-0@sha256:5c51ab87bfddc55868364dd9b265ea8c19455926663d8abfc023dd455540ff65
+export MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-5-0@sha256:fb4b8b82ff76a91f8fbd8b8318885b5deeff069bd9dae10789fb5aac193a40fc
 export MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@${MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE##*@}"
 
 export MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-5-0@sha256:fbc57f5e2b972cabca9b1884fd3375569836a6bc1ae08a56f33205f5fefc103d


### PR DESCRIPTION
## Summary
- Update `konflux-patch.sh` agent, manager, and operator digests to match snapshot `release-globalhub-5-0-20260618-201121-000`
- Fixes stage publish `verify-conforma` `olm.unmapped_references` (component SHAs in bundle CSV must match snapshot)

## Digest changes
| Component | Old (partial Konflux updates) | New (snapshot) |
|-----------|------------------------------|----------------|
| agent | `d2e7dd7…` | `04d334ae…` |
| manager | `9dfb9e0…` | `0872bfa…` |
| operator | `5c51ab8…` | `fb4b8b82…` |
| grafana | `fbc57f5…` | unchanged |
| postgres-exporter | `4c03b55…` | unchanged |

Supersedes Konflux bot PR #1263 (manager-only update).

## Test plan
- [ ] Konflux bundle build succeeds on PR
- [ ] Merge → new app snapshot → auto `stage-publish-globalhub-5-0` passes `verify-conforma`


Made with [Cursor](https://cursor.com)