### PR TITLE
Bump bundle CSV version to 5.0.0 for GH 5.0 GA

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.7.0 <1.8.0'
+    olm.skipRange: '>=1.8.0 <5.0.0'
     operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
       "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"},
       "spec": {}}'
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.8.0
+  name: multicluster-global-hub-operator.v5.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1432,8 +1432,8 @@ spec:
   maintainers:
   - email: acm-contact@redhat.com
     name: acm-contact
-  maturity: release-1.8
+  maturity: release-5.0
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 1.8.0
+  version: 5.0.0

--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -58,5 +58,5 @@ sed -i \
 	"${csv_file}"
 
 sed -i -e "s|multicluster-global-hub-operator\\.v|multicluster-global-hub-operator-rh\\.v|g" "${csv_file}"
-sed -i -e "s|5.0.0-dev|1.8.0|g" "${csv_file}"
+sed -i -e "s|5.0.0-dev|5.0.0|g" "${csv_file}"
 sed -i -e "s|multicluster-global-hub-operator|multicluster-global-hub-operator-rh|g" "metadata/annotations.yaml"

--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -58,5 +58,5 @@ sed -i \
 	"${csv_file}"
 
 sed -i -e "s|multicluster-global-hub-operator\\.v|multicluster-global-hub-operator-rh\\.v|g" "${csv_file}"
-sed -i -e "s|1.8.0-dev|1.8.0|g" "${csv_file}"
+sed -i -e "s|5.0.0-dev|1.8.0|g" "${csv_file}"
 sed -i -e "s|multicluster-global-hub-operator|multicluster-global-hub-operator-rh|g" "metadata/annotations.yaml"


### PR DESCRIPTION
## Summary
- Bump CSV from `1.8.0` → `5.0.0` on `release-5.0` channel
- Update `olm.skipRange` to `>=1.8.0 <5.0.0`, maturity to `release-5.0`
- Update `konflux-patch.sh` to strip `5.0.0-dev` → `5.0.0`

## Why
Stage catalog currently advertises `multicluster-global-hub-operator-rh.v1.8.0` in the `release-5.0` channel.

## Test plan
- [ ] Konflux bundle build succeeds after merge
- [ ] Catalog template digest updated after new bundle snapshot (follow-up PR or MintMaker)

Companion: stolostron/multicluster-global-hub#2535


Made with [Cursor](https://cursor.com)