### PR TITLE
ACM-30175: Sync operator CSV RBAC for TLS profile support (#2487)

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -355,6 +355,12 @@ spec:
           - list
           - watch
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - apiservers
+          verbs:
+          - get
+        - apiGroups:
           - addon.open-cluster-management.io
           resources:
           - addondeploymentconfigs
@@ -961,6 +967,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - apiservers
+          verbs:
+          - get
         - apiGroups:
           - config.openshift.io
           resources:


### PR DESCRIPTION
Fixes: [ACM-30175](https://redhat.atlassian.net/browse/ACM-30175)

## Summary

- Add `config.openshift.io/apiservers` `get` to the operator CSV `clusterPermissions` (two rule blocks), matching `stolostron/multicluster-global-hub` `release-5.0` (`operator/config/rbac/role.yaml` / `operator/bundle/manifests/...`).
- This permission is required for [TLS profile support](https://github.com/stolostron/multicluster-global-hub/pull/2487) ([ACM-30175](https://redhat.atlassian.net/browse/ACM-30175)): the manager reads the cluster `APIServer` config to align with the OpenShift cluster-wide TLS security profile.
- Without it, the operator cannot create the manager ClusterRole (RBAC escalation). Manager never deploys and MCGH stays `Ready=False` / `MulticlusterGlobalHubNotReady`.

## Context

The main repo gained `apiservers get` as part of #2487, but the bundle repo CSV was not synced before the GH 5.0 stage bundle shipped.

Observed on GH 5.0 stage install (`globalhub-operator-install #1099`, hub `vbirsan--gh-776`, `regionalhub-import #579`):

```
failed to create/update manager objects: clusterroles.rbac.authorization.k8s.io "multicluster-global-hub:multicluster-global-hub-manager" is forbidden: user "system:serviceaccount:multicluster-global-hub:multicluster-global-hub-operator" is attempting to grant RBAC permissions not currently held:
{APIGroups:["config.openshift.io"], Resources:["apiservers"], Verbs:["get"]}
```

Related:
- [stolostron/multicluster-global-hub#2487](https://github.com/stolostron/multicluster-global-hub/pull/2487) — TLS profile support
- [ACM-30175](https://redhat.atlassian.net/browse/ACM-30175) — TLS profile Jira

## Test plan

- [ ] Merge and cut a new stage bundle / catalog entry
- [ ] Fresh install on OpenShift: MCGH reaches `Ready=True`, manager pods Running
- [ ] `regionalhub-import` BeforeSuite health check passes without manual ClusterRole patch

[ACM-30175]: https://redhat.atlassian.net/browse/ACM-30175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-30175]: https://redhat.atlassian.net/browse/ACM-30175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-30175]: https://redhat.atlassian.net/browse/ACM-30175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ