### PR TITLE
ACM-31409/ACM-36415: Add networkpolicies RBAC to GH 5.0 operator CSV

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -1104,6 +1104,17 @@ spec:
           - get
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - observability.open-cluster-management.io
           resources:
           - observabilityaddons


### PR DESCRIPTION
Fixes: [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409)
[ACM-36415](https://redhat.atlassian.net/browse/ACM-36415)

## Summary
- Adds `networking.k8s.io/networkpolicies` permissions to the operator ClusterRole in the CSV
- Syncs with `multicluster-global-hub` `operator/config/rbac/role.yaml` on `release-5.0` ([#2493](https://github.com/stolostron/multicluster-global-hub/pull/2493))

## Problem
GH 5.0.0 operator code deploys NetworkPolicies for postgres, kafka, manager, grafana, etc., but the `release-5.0` operator-bundle CSV shipped without the RBAC rule. OLM installs the operator with a ClusterRole that cannot get/list/watch/create networkpolicies, so `MulticlusterGlobalHub` stays **NotReady** with postgres `ReconcileError` and no operand pods come up.

Observed on Jenkins `globalhub-create #777` / cluster `vbirsan--gh-777` with `fbc-stage` catalog `release-5.0`.

## Test plan
- [ ] Merge and publish new stage bundle via Konflux
- [ ] Fresh GH 5.0 install: `oc auth can-i list networkpolicies --as=system:serviceaccount:multicluster-global-hub:multicluster-global-hub-operator -n multicluster-global-hub` → yes
- [ ] MCGH reaches **Running**; networkpolicies created in `multicluster-global-hub'

[ACM-31409]: https://redhat.atlassian.net/browse/ACM-31409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACM-36415]: https://redhat.atlassian.net/browse/ACM-36415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ