### PR TITLE
Update GH 5.0 konflux-patch postgres-exporter digest

### DIFF
--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -14,7 +14,7 @@ export MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE="registry.redhat.io/multicluster-g
 export MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-5-0@sha256:607a30df2ef5c362b666c64c8af30ab3f1be3dd379cf3db8850942566be25eee
 export MULTICLUSTER_GLOBAL_HUB_GRAFANA_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-grafana-rhel9@${MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE##*@}"
 
-export MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-5-0@sha256:5f5524b93adf772f0000160479d9df812121bb95ec1128be8d5d82947e4534bd
+export MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-5-0@sha256:2288cffee7e8a7b9b954d24c902fd99d00751eeba6f439ae2fe905ffdf05fa66
 export MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9@${MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_STAGE_IMAGE##*@}"
 
 export MULTICLUSTER_GLOBAL_HUB_POSTGRESQL_IMAGE=registry.redhat.io/rhel9/postgresql-16@sha256:ec25d82d69202fa306da376132d4f23d7c4e865c95e7030f13f9f95ffe4191c5


### PR DESCRIPTION
## Summary
- Update `MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_STAGE_IMAGE` to `2288cffee…` (promoted after postgres_exporter#207)
- Fixes `verify-conforma` `olm.unmapped_references` on stale CSV refs (`5f5524b9…` manager/postgres) in bundle `fa67904`

Stage release snapshot `20260626-020918` had new operand digests but bundle CSV was built from partial MintMaker nudges (#1331 operator, #1332 agent only).

## Test plan
- [ ] Bundle on-push succeeds
- [ ] New app snapshot → stage release passes verify-conforma

Made with [Cursor](https://cursor.com)