### PR TITLE
ACM-32313/ACM-36415: Sync operator CSV RBAC for NetworkPolicy ipBlock resolution (#2617)

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -361,6 +361,14 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - networks
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - addon.open-cluster-management.io
           resources:
           - addondeploymentconfigs
@@ -678,6 +686,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - discovery.k8s.io
+          resources:
+          - endpointslices
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - ""
           resources:
           - groups
@@ -973,6 +989,14 @@ spec:
           - apiservers
           verbs:
           - get
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - networks
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - config.openshift.io
           resources:
@@ -1385,6 +1409,7 @@ spec:
           - services
           - services/finalizers
           - endpoints
+          - endpointslices
           - events
           - configmaps
           - secrets


### PR DESCRIPTION
Fixes: [ACM-32313](https://redhat.atlassian.net/browse/ACM-32313)
[ACM-36415](https://redhat.atlassian.net/browse/ACM-36415)

## Summary

- Add `discovery.k8s.io/endpointslices` `get;list;watch` to the operator CSV `clusterPermissions`, matching [multicluster-global-hub#2617](https://github.com/stolostron/multicluster-global-hub/pull/2617) on `main` (`operator/config/rbac/role.yaml` / `operator/bundle/manifests/...`).
- Add `config.openshift.io/networks` `get;list;watch` in both `apiservers` rule blocks (same CSV sync pattern as [operator-bundle#1289](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1289)).
- Required for ACM-32313 NetworkPolicy `ipBlock` hardening: the operator resolves Kubernetes API server endpoints and OpenShift service network CIDR at reconcile time.

## Context

GH 5.0 operator-bundle CSV must stay in sync with the main repo operator ClusterRole. Prior bundle fixes for related work:

- [operator-bundle#1289](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1289) — `apiservers` `get` (ACM-30175 / TLS profile)
- [operator-bundle#1323](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1323) — `networkpolicies` RBAC (ACM-31409 / #2493)

Without `endpointslices` and `networks` in the CSV-installed ClusterRole, OLM may install an operator SA that cannot resolve addresses for `ipBlock` rules; NetworkPolicy reconciliation falls back to broad egress or fails RBAC escalation when granting child roles.

Related:

- [multicluster-global-hub#2617](https://github.com/stolostron/multicluster-global-hub/pull/2617) — ipBlock hardening (parent product PR)
- [multicluster-global-hub#2493](https://github.com/stolostron/multicluster-global-hub/pull/2493) — NetworkPolicy support
- [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409) — NetworkPolicy epic

## Test plan

- [ ] Merge and publish new stage bundle via Konflux
- [ ] Fresh GH 5.0 install: operator SA can `get/list/watch endpointslices` and `networks`
- [ ] `allow-dns-and-api` and agent NetworkPolicies render with `ipBlock` rules (not only fallback) after [#2617](https://github.com/stolostron/multicluster-global-hub/pull/2617) is in the shipped operator image


Made with [Cursor](https://cursor.com)

[ACM-32313]: https://redhat.atlassian.net/browse/ACM-32313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-31409]: https://redhat.atlassian.net/browse/ACM-31409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACM-36415]: https://redhat.atlassian.net/browse/ACM-36415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ