### PR TITLE
ACM-30175: Sync operator CSV RBAC for IngressController TLS (#2626)

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -361,6 +361,14 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - config.openshift.io
           resources:
           - networks
@@ -989,6 +997,14 @@ spec:
           - apiservers
           verbs:
           - get
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - config.openshift.io
           resources:


### PR DESCRIPTION
Fixes: [ACM-30175](https://redhat.atlassian.net/browse/ACM-30175)

## Summary

- Add `ingresscontrollers` get/list/watch to the operator ClusterServiceVersion RBAC (both permission blocks)
- Mirrors [stolostron/multicluster-global-hub#2626](https://github.com/stolostron/multicluster-global-hub/pull/2626) so GH 5.0 OLM installs can read IngressController TLS profiles for Grafana Route edge TLS

## Context

- Product PR [#2626](https://github.com/stolostron/multicluster-global-hub/pull/2626) switches Grafana to Route edge + IngressController `status.tlsProfile`
- Grafana reconciler needs `operator.openshift.io/ingresscontrollers` RBAC; OLM uses this bundle CSV, not the main-repo YAML alone
- Same companion pattern as [#1460](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1460) (ACM-32313 NetworkPolicy RBAC sync)

Related:

- [ACM-30175](https://redhat.atlassian.net/browse/ACM-30175) — Jira
- [stolostron/multicluster-global-hub#2626](https://github.com/stolostron/multicluster-global-hub/pull/2626) — Ingress TLS product PR

## Test plan

- [ ] CSV diff matches main-repo bundle RBAC from #2626
- [ ] Bundle CI green after merge
- [ ] Stage Konflux bundle build picks up merged CSV

Made with [Cursor](https://cursor.com)

[ACM-30175]: https://redhat.atlassian.net/browse/ACM-30175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-30175]: https://redhat.atlassian.net/browse/ACM-30175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ