### PR TITLE
Add rohit-bharmal to OWNERS on main

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,10 @@
 approvers:
 - bjoydeep
 - birsanv
+- rohit-bharmal
 
 reviewers:
 - bjoydeep
 - birsanv
+- rohit-bharmal
 - red-hat-konflux


### PR DESCRIPTION
## Summary
- Add `rohit-bharmal` to `OWNERS` approvers and reviewers (same placement as `bjoydeep` / `birsanv`)

## Test plan
- [ ] Prow/OWNERS validation passes on merge