### PR TITLE
chore(deps): update glo-grafana-globalhub-1-6 to c8b304a

### DIFF
--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -11,7 +11,7 @@ export MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE="registry.redhat.io/multicluster-gl
 export MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-1-6@sha256:3377cc3e0be1880a6ed6d1a8aaf5b511efb0effb1640ddd23606e56d6a0f3118
 export MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@${MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE##*@}"
 
-export MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-6@sha256:14ad58e9325f62920b37f7a0935c138a378d54df8043abef51b7ef4f5b8f5cfb
+export MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-6@sha256:c8b304a1265783766f6fcc6f1d973054e97e0624a3da890e0bac5f3ef43752c5
 export MULTICLUSTER_GLOBAL_HUB_GRAFANA_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-grafana-rhel9@${MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE##*@}"
 
 export MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-6@sha256:c6cac0581f403abfa58aa5ad08833ebcd957905badcc5ab1b78c0248e2cd73b6


### PR DESCRIPTION
## Summary
- Update `MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE` in `konflux-patch.sh` from `14ad58e9…` to `c8b304a1…`
- Matches current Konflux promoted grafana (`glo-grafana-globalhub-1-6`, git `241c4628`)

## Why
Bundle stage `stage-publish-globalhub-1-6-4-rc2` failed `verify-conforma` with `olm.unmapped_references`: snapshot has grafana `c8b304a1…` but bundle CSV still referenced stale `14ad58e9…` (404 on `registry.redhat.io`).

MintMaker nudge [#1594](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1594) only reached `14ad58e`; grafana was rebuilt to `c8b304a` without a follow-up nudge.

## Test plan
- [ ] Konflux on-push + EC green on `release-1.6`
- [ ] New `release-globalhub-1-6` snapshot: bundle digest changes and grafana in snapshot stays `c8b304a1…`
- [ ] Retry bundle stage rc2

Made with [Cursor](https://cursor.com)