### PR TITLE
fix: bump rpms-signature-scan to trusted digest for stage EC

### DIFF
--- a/.tekton/multicluster-global-hub-operator-bundle-globalhub-5-0-pull-request.yaml
+++ b/.tekton/multicluster-global-hub-operator-bundle-globalhub-5-0-pull-request.yaml
@@ -511,7 +511,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:41720da9dfe26f33b0bdc46bbf8667a27dae4790d8e5c5f4412224658de7b213
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:ccb77d1bf7627fc6241a59ed42bb6e5707a8682754fe8ae18f2cfdddbcf29275
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/multicluster-global-hub-operator-bundle-globalhub-5-0-push.yaml
+++ b/.tekton/multicluster-global-hub-operator-bundle-globalhub-5-0-push.yaml
@@ -508,7 +508,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:41720da9dfe26f33b0bdc46bbf8667a27dae4790d8e5c5f4412224658de7b213
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:ccb77d1bf7627fc6241a59ed42bb6e5707a8682754fe8ae18f2cfdddbcf29275
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary

- Bump `rpms-signature-scan` Tekton task digest in 5.0 push and PR pipelines to the trusted version required by `registry-standard-stage`
- Fixes stage `verify-conforma` failures: `tasks.required_untrusted_task_found` / `trusted_task.trusted` on the operator-bundle image

## Context

- Failed stage release: `stage-publish-globalhub-5-0-0-20260724` (`managed-rzlkc`)
- Filter kept all 6 components; only the bundle failed EC
- Current pin: `sha256:41720da9…` → required: `sha256:ccb77d1bf7627fc6241a59ed42bb6e5707a8682754fe8ae18f2cfdddbcf29275`

## Test plan

- [ ] PR Konflux build succeeds
- [ ] After merge, bundle `on-push` succeeds and GitHub EC is green/neutral
- [ ] Retry `stage-publish-globalhub-5-0` — `verify-conforma` passes