### PR TITLE
chore(deps): update glo-grafana-globalhub-5-0 to faf9d40

### DIFF
--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -11,7 +11,7 @@ export MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE="registry.redhat.io/multicluster-gl
 export MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-5-0@sha256:db3e5df0117717fa6135294a88c4fceebc4af989941f5d0f8789767df95a8ad5
 export MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@${MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE##*@}"
 
-export MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-5-0@sha256:2e0996ee0d6e1edc7f35d7440534301f9c9020ddd99ec6fb1f2537d82906c494
+export MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-5-0@sha256:faf9d40d87f60550cef65cfc930b607ba4bb505b3f66e9a38166a0dfc709acc3
 export MULTICLUSTER_GLOBAL_HUB_GRAFANA_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-grafana-rhel9@${MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE##*@}"
 
 export MULTICLUSTER_GLOBAL_HUB_POSTGRES_EXPORTER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-5-0@sha256:c5b3d1b9831ae1eec1e1d274d3ad60e092c1a3d4920e6c96a10462a3aa92d823


### PR DESCRIPTION
## Summary

- Manual MintMaker-style nudge: update `MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE` in `konflux-patch.sh` from `sha256:2e0996ee…` to `sha256:faf9d40d…`
- Aligns bundle CSV with the promoted grafana image in the current 5.0 application snapshot

## Context

- After [#1657](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1657) fixed `rpms-signature-scan` trust, stage release `stage-publish-globalhub-5-0-0-20260724` (`managed-c9xt6`) failed `verify-conforma` with:
  - `olm.unmapped_references` for `…grafana-rhel9@sha256:2e0996ee…`
- Snapshot `release-globalhub-5-0-20260724-162852-000` already has grafana `faf9d40`; CSV was still on the old digest
- No open MintMaker PR for this nudge

## Test plan

- [ ] Bundle on-push after merge succeeds
- [ ] New snapshot CSV grafana digest matches `faf9d40`
- [ ] Retry stage bundle release — `verify-conforma` passes


Made with [Cursor](https://cursor.com)