### PR TITLE
fix: align grafana/postgres mirror set with globalhub-1-8

### DIFF
--- a/.tekton/images_digest_mirror_set.yaml
+++ b/.tekton/images_digest_mirror_set.yaml
@@ -15,8 +15,8 @@ spec:
         - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-1-8
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-6
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-8
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-grafana-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-6
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-8
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9


### PR DESCRIPTION
## Summary

Fixes stale `ImageDigestMirrorSet` entries on `release-1.8`.

When 1.8 was cut (#733), agent/manager/operator mirrors were bumped to `globalhub-1-8`, but grafana and postgres-exporter still pointed at `globalhub-1-6` quay repos. Meanwhile `konflux-patch.sh` on the same branch already uses `glo-grafana-globalhub-1-8` and `postgres-exporter-globalhub-1-8` stage digests.

Clusters using this mirror set for stage/QE testing would redirect grafana/postgres pulls to the wrong Konflux component line.

## Changes

- `glo-grafana-globalhub-1-6` → `glo-grafana-globalhub-1-8`
- `postgres-exporter-globalhub-1-6` → `postgres-exporter-globalhub-1-8`

## Test plan

- [ ] Verify mirror entries match `konflux-patch.sh` Konflux component names on `release-1.8`
- [ ] Apply updated IDMS on a stage cluster and confirm grafana/postgres pulls resolve from `globalhub-1-8` quay repos


Made with [Cursor](https://cursor.com)