### PR TITLE
fix: align grafana/postgres mirror set with globalhub-1-7

### DIFF
--- a/.tekton/images_digest_mirror_set.yaml
+++ b/.tekton/images_digest_mirror_set.yaml
@@ -15,7 +15,7 @@ spec:
         - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-1-7
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-6
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-7
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-grafana-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-7

--- a/.tekton/images_digest_mirror_set.yaml
+++ b/.tekton/images_digest_mirror_set.yaml
@@ -18,5 +18,5 @@ spec:
         - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-6
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-grafana-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-6
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-7
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9


### PR DESCRIPTION
## Summary

Backport mirror-set fix for `release-1.7`.

Since the 1.7 release cut, `konflux-patch.sh` has used `glo-grafana-globalhub-1-7` and `postgres-exporter-globalhub-1-7` stage digests, but `ImageDigestMirrorSet` still pointed grafana/postgres at `globalhub-1-6` quay repos.

## Changes

- `glo-grafana-globalhub-1-6` → `glo-grafana-globalhub-1-7`
- `postgres-exporter-globalhub-1-6` → `postgres-exporter-globalhub-1-7`

Companion: #1666 (same fix for `release-1.8`)

## Test plan

- [ ] Verify mirror entries match `konflux-patch.sh` on `release-1.7`


Made with [Cursor](https://cursor.com)