### PR TITLE
ACM-39301: sync ZTP migration operator RBAC to release-1.6 CSV

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2025-08-27T07:10:21Z"
+    createdAt: "2026-08-03T13:21:19Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -766,6 +766,18 @@ spec:
           - update
           - watch
         - apiGroups:
+          - extensions.hive.openshift.io
+          resources:
+          - imageclusterinstalls
+          - imageclusterinstalls/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - global-hub.open-cluster-management.io
           resources:
           - managedclustermigrations
@@ -775,6 +787,18 @@ spec:
           - get
           - list
           - patch
+          - update
+          - watch
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - clusterdeployments
+          - clusterdeployments/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
           - update
           - watch
         - apiGroups:
@@ -809,6 +833,25 @@ spec:
           - update
           - watch
         - apiGroups:
+          - metal3.io
+          resources:
+          - baremetalhosts
+          - baremetalhosts/status
+          - dataimages
+          - firmwareschemas
+          - firmwareschemas/status
+          - hostfirmwarecomponents
+          - hostfirmwarecomponents/status
+          - hostfirmwaresettings
+          - hostfirmwaresettings/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - podmonitors
@@ -830,6 +873,15 @@ spec:
           verbs:
           - create
           - get
+          - update
+        - apiGroups:
+          - observability.open-cluster-management.io
+          resources:
+          - observabilityaddons
+          verbs:
+          - delete
+          - get
+          - list
           - update
         - apiGroups:
           - operator.open-cluster-management.io


### PR DESCRIPTION
## Summary
- Add hive, metal3, and observability addon `clusterPermissions` to the operator CSV on `release-1.6`
- Mirrors operator RBAC from [stolostron/multicluster-global-hub#2725](https://github.com/stolostron/multicluster-global-hub/pull/2725) (`operator/config/rbac/role.yaml`) so OLM installs grant RBAC escalation for local-agent ZTP migration

## Related
- [multicluster-global-hub#2725](https://github.com/stolostron/multicluster-global-hub/pull/2725) — ACM-39301 ZTP migration agent/operator RBAC backport to release-2.15 (GH 1.6.5)
- Same RBAC block as [#2709](https://github.com/stolostron/multicluster-global-hub/pull/2709) (GH 1.7)

## Test plan
- [ ] CI passes (YAML-only CSV change)
- [ ] After merge, `verify bundle` on #2725 can pick up synced `operator/bundle/` in a follow-up commit if needed


Made with [Cursor](https://cursor.com)