### PR TITLE
ACM-39301: sync ZTP migration operator RBAC to release-1.5 CSV

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -739,6 +739,18 @@ spec:
           - update
           - watch
         - apiGroups:
+          - extensions.hive.openshift.io
+          resources:
+          - imageclusterinstalls
+          - imageclusterinstalls/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - global-hub.open-cluster-management.io
           resources:
           - managedclustermigrations
@@ -748,6 +760,18 @@ spec:
           - get
           - list
           - patch
+          - update
+          - watch
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - clusterdeployments
+          - clusterdeployments/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
           - update
           - watch
         - apiGroups:
@@ -782,6 +806,25 @@ spec:
           - update
           - watch
         - apiGroups:
+          - metal3.io
+          resources:
+          - baremetalhosts
+          - baremetalhosts/status
+          - dataimages
+          - firmwareschemas
+          - firmwareschemas/status
+          - hostfirmwarecomponents
+          - hostfirmwarecomponents/status
+          - hostfirmwaresettings
+          - hostfirmwaresettings/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - podmonitors
@@ -803,6 +846,15 @@ spec:
           verbs:
           - create
           - get
+          - update
+        - apiGroups:
+          - observability.open-cluster-management.io
+          resources:
+          - observabilityaddons
+          verbs:
+          - delete
+          - get
+          - list
           - update
         - apiGroups:
           - operator.open-cluster-management.io


### PR DESCRIPTION
## Summary

- Add hive, metal3, and observability addon `clusterPermissions` to the operator CSV on `release-1.5`
- Mirrors operator RBAC from multicluster-global-hub `release-2.14` PR (GH 1.5) / same RBAC block as [#1746](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1746) (GH 1.6)

## Related

- ACM-39301
- multicluster-global-hub PR on `release-2.14` (companion operator RBAC backport)
- [#1746](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1746) — GH 1.6 bundle CSV sync

## Test plan

- [ ] CI passes (YAML-only CSV change)


Made with [Cursor](https://cursor.com)