### PR TITLE
Trigger Konflux on-push for 1.5.7 CSV fix rebuild

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -1,3 +1,4 @@
+# Trigger Konflux on-push after CSV duplicate removal (#1769).
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 WORKDIR /


### PR DESCRIPTION
## Summary

- Adds a comment to `Containerfile.bundle` so the `release-1.5` on-push CEL matches after #1769
- #1769 only deleted `bundle/manifests/...yaml''`, which did not trigger on-push; manual `request=build` is rejected (`unexpected build request: build`)

## Related

- #1769 — remove duplicate CSV manifest (GH 1.5.7 `BundleUnpackFailed` fix)

## Test plan

- [ ] Merge → `multicluster-global-hub-operator-bundle-globalhub-1-5-on-push` green on merge commit
- [ ] Run `stage-publish-globalhub-1-5-7-rc3`


Made with [Cursor](https://cursor.com)