### PR TITLE
ACM-31409/ ACM-36415: Add networkpolicies RBAC to GH 1.8 operator CSV

### DIFF
--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -1092,6 +1092,17 @@ spec:
           - get
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - observability.open-cluster-management.io
           resources:
           - observabilityaddons


### PR DESCRIPTION
Fixes [ACM-36415](https://redhat.atlassian.net/browse/ACM-36415)
## Summary
- Adds `networking.k8s.io/networkpolicies` permissions to the operator ClusterRole in the CSV `clusterPermissions` (same block as [#1323](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1323) on `release-5.0`)
- Unblocks **GH 1.8.1 prod** bundle publish: `prod-publish-globalhub-1-8-1-rc3` failed `verify-conforma` on `olm.required_network_policy_rbac_for_operands` (policy effective 2026-08-07)

## Problem
Prod bundle conforma requires operators to declare NetworkPolicy lifecycle RBAC (`create`, `delete`, `update/patch` on `networking.k8s.io/networkpolicies`). `release-1.8` CSV never received the #1323 sync. Stage rc3 (Aug 3) passed before the rule was enforced; prod (Aug 10) fails.

## Scope
- **CSV-only** — no operand image changes; rc4 bundle digest will differ from rc3 only because of this manifest update
- 1.8 operator code on `release-2.17` does not deploy NetworkPolicies; this satisfies prod release policy only

## Related
- Fixes: [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409)
- 5.0 precedent: [#1323](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1323)

## Test plan
- [ ] Merge → bundle on-push + EC green on `release-1.8`
- [ ] Bundle stage rc4 → catalog nudge → catalog stage rc4 → bundle prod rc4
- [ ] Prod `verify-conforma` passes `olm.required_network_policy_rbac_for_operands`


Made with [Cursor](https://cursor.com)

[ACM-31409]: https://redhat.atlassian.net/browse/ACM-31409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACM-36415]: https://redhat.atlassian.net/browse/ACM-36415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ