### PR TITLE
chore(deps): update operator-globalhub-1-8 to fa39e1d for rc4 stage

### DIFF
--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -8,7 +8,7 @@ export MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE="registry.redhat.io/multicluster-glob
 export MULTICLUSTER_GLOBAL_HUB_MANAGER_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-1-8@sha256:1cf00cedf84993d85254453a6fee5b8ee6e9d4d062768b682b42b0e63012ea73
 export MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-manager-rhel9@${MULTICLUSTER_GLOBAL_HUB_MANAGER_STAGE_IMAGE##*@}"
 
-export MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-1-8@sha256:ebc19a50f2c1b39f8b8f8c190900740ff1b4bf7cea651d7bb210a1abef9cacf4
+export MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-1-8@sha256:fa39e1d8ad329ebe341598df25dae4a388b34c28056732ed519ca8c3acb265c7
 export MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE="registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator@${MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE##*@}"
 
 export MULTICLUSTER_GLOBAL_HUB_GRAFANA_STAGE_IMAGE=quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-1-8@sha256:71e6b91840fba2e4dd6aa0a0cf1c55d541d70edcbbf2570f49a5ef692402e942


### PR DESCRIPTION
## Summary
- Bumps `MULTICLUSTER_GLOBAL_HUB_OPERATOR_STAGE_IMAGE` in `konflux-patch.sh` from `ebc19a50` → `fa39e1d`
- Aligns bundle CSV operator ref with the operator component already in latest Konflux application snapshots (Aug 7 build)

## Problem
`stage-publish-globalhub-1-8-1-rc4` failed `verify-conforma` on `olm.unmapped_references`:
- Bundle `87a5d8e` (post-#1778 NetworkPolicy RBAC) CSV still referenced operator `ebc19a50` (rc3)
- Application snapshot already had operator `fa39e1d` from Konflux component rebuild

Supersedes closed nudge [#1772](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1772).

## Related
- [#1778](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1778) — NetworkPolicy CSV RBAC (merged)
- Operator source: `multicluster-global-hub@96aa46de` (Konflux build `fa39e1d`)

## Test plan
- [ ] Merge → bundle on-push + EC green on `release-1.8`
- [ ] Delete failed `stage-publish-globalhub-1-8-1-rc4`, wait 300s
- [ ] Re-run bundle stage rc4 → `verify-conforma` passes (no `unmapped_references`, NetworkPolicy RBAC still passes)


Made with [Cursor](https://cursor.com)