### PR TITLE
fix: update bundle CPE and channel labels to 5.1

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -14,8 +14,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multicluster-global-hub-operator-rh
-LABEL operators.operatorframework.io.bundle.channels.v1=release-5.0
-LABEL operators.operatorframework.io.bundle.channel.default.v1=release-5.0
+LABEL operators.operatorframework.io.bundle.channels.v1=release-5.1
+LABEL operators.operatorframework.io.bundle.channel.default.v1=release-5.1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
@@ -23,11 +23,11 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-globalhub-operator-bundle-container"
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.0::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.1::el9"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-operator-bundle"
-LABEL version="release-5.0"
+LABEL version="release-5.1"
 LABEL summary="multicluster global hub operator bundle"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
## Summary
The release-5.1 branch was created from release-5.0 but the Containerfile bundle labels were not updated. This causes `check-labels` to fail during stage release because the RPA expects CPE `5.1`.

## Changes
- `operators.operatorframework.io.bundle.channels.v1`: release-5.0 → release-5.1
- `operators.operatorframework.io.bundle.channel.default.v1`: release-5.0 → release-5.1
- `cpe`: 5.0 → 5.1
- `version`: release-5.0 → release-5.1

## Related
- ACM-40739
- Fixes stage-publish-globalhub-5-1 check-labels failure

Made with [Cursor](https://cursor.com)