### PR TITLE
Add Global Hub 5.2 bundle configuration

### DIFF
--- a/.tekton/images_digest_mirror_set.yaml
+++ b/.tekton/images_digest_mirror_set.yaml
@@ -6,17 +6,17 @@ metadata:
 spec:
   imageDigestMirrors:
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-agent-globalhub-5-1
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-agent-globalhub-5-2
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-agent-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-5-1
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-5-2
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-manager-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-5-1
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-5-2
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-rhel9-operator
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-5-1
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/glo-grafana-globalhub-5-2
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-grafana-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-5-1
+        - quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-5-2
       source: registry.redhat.io/multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9

--- a/.tekton/multicluster-global-hub-operator-bundle-globalhub-5-2-pull-request.yaml
+++ b/.tekton/multicluster-global-hub-operator-bundle-globalhub-5-2-pull-request.yaml
@@ -4,15 +4,16 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub-operator-bundle?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-5.1"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-5.2"
   labels:
-    appstudio.openshift.io/application: release-globalhub-5-1
-    appstudio.openshift.io/component: multicluster-global-hub-operator-bundle-globalhub-5-1
+    appstudio.openshift.io/application: release-globalhub-5-2
+    appstudio.openshift.io/component: multicluster-global-hub-operator-bundle-globalhub-5-2
     pipelines.appstudio.openshift.io/type: build
-  name: multicluster-global-hub-operator-bundle-globalhub-5-1-on-push
+  name: multicluster-global-hub-operator-bundle-globalhub-5-2-on-pull-request
   namespace: acm-multicluster-glo-tenant
 spec:
   params:
@@ -21,7 +22,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-bundle-globalhub-5-1:{{revision}}
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-bundle-globalhub-5-2:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: dockerfile
     value: Containerfile.bundle
   - name: path-context
@@ -40,7 +43,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-oci-ta.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-multicluster-global-hub-operator-bundle-globalhub-5-1
+    serviceAccountName: build-pipeline-multicluster-global-hub-operator-bundle-globalhub-5-2
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/multicluster-global-hub-operator-bundle-globalhub-5-2-push.yaml
+++ b/.tekton/multicluster-global-hub-operator-bundle-globalhub-5-2-push.yaml
@@ -4,16 +4,15 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub-operator-bundle?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-5.1"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-5.2"
   labels:
-    appstudio.openshift.io/application: release-globalhub-5-1
-    appstudio.openshift.io/component: multicluster-global-hub-operator-bundle-globalhub-5-1
+    appstudio.openshift.io/application: release-globalhub-5-2
+    appstudio.openshift.io/component: multicluster-global-hub-operator-bundle-globalhub-5-2
     pipelines.appstudio.openshift.io/type: build
-  name: multicluster-global-hub-operator-bundle-globalhub-5-1-on-pull-request
+  name: multicluster-global-hub-operator-bundle-globalhub-5-2-on-push
   namespace: acm-multicluster-glo-tenant
 spec:
   params:
@@ -22,9 +21,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-bundle-globalhub-5-1:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-bundle-globalhub-5-2:{{revision}}
   - name: dockerfile
     value: Containerfile.bundle
   - name: path-context
@@ -43,7 +40,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-oci-ta.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-multicluster-global-hub-operator-bundle-globalhub-5-1
+    serviceAccountName: build-pipeline-multicluster-global-hub-operator-bundle-globalhub-5-2
   workspaces:
   - name: git-auth
     secret:

--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -14,8 +14,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multicluster-global-hub-operator-rh
-LABEL operators.operatorframework.io.bundle.channels.v1=release-5.1
-LABEL operators.operatorframework.io.bundle.channel.default.v1=release-5.1
+LABEL operators.operatorframework.io.bundle.channels.v1=release-5.2
+LABEL operators.operatorframework.io.bundle.channel.default.v1=release-5.2
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
@@ -23,11 +23,11 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-globalhub-operator-bundle-container"
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.1::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.2::el9"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-operator-bundle"
-LABEL version="release-5.1"
+LABEL version="release-5.2"
 LABEL summary="multicluster global hub operator bundle"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"

--- a/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=5.0.0 <5.1.0'
+    olm.skipRange: '>=5.1.0 <5.2.0'
     operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
       "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"},
       "spec": {}}'
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v5.1.0
+  name: multicluster-global-hub-operator.v5.2.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1496,8 +1496,8 @@ spec:
   maintainers:
   - email: acm-contact@redhat.com
     name: acm-contact
-  maturity: release-5.1
+  maturity: release-5.2
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 5.1.0
+  version: 5.2.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,8 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: multicluster-global-hub-operator
-  operators.operatorframework.io.bundle.channels.v1: release-5.1
-  operators.operatorframework.io.bundle.channel.default.v1: release-5.1
+  operators.operatorframework.io.bundle.channels.v1: release-5.2
+  operators.operatorframework.io.bundle.channel.default.v1: release-5.2
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4

--- a/konflux-patch.sh
+++ b/konflux-patch.sh
@@ -58,5 +58,5 @@ sed -i \
 	"${csv_file}"
 
 sed -i -e "s|multicluster-global-hub-operator\\.v|multicluster-global-hub-operator-rh\\.v|g" "${csv_file}"
-sed -i -e "s|5.1.0-dev|5.1.0|g" "${csv_file}"
+sed -i -e "s|5.2.0-dev|5.2.0|g" "${csv_file}"
 sed -i -e "s|multicluster-global-hub-operator|multicluster-global-hub-operator-rh|g" "metadata/annotations.yaml"


### PR DESCRIPTION
## Summary

- rename the Global Hub 5.1 bundle pipelines for the 5.2 release line
- update Konflux application/component names, branch filters, image targets, and mirror mappings
- update bundle channel, CPE, CSV version, and skip range for 5.2

## Bootstrap note

The existing 5.1 operand image digests in `konflux-patch.sh` are intentionally retained until the GH 5.2 operand Components produce images. Konflux/MintMaker should replace them with 5.2 image digests afterward.

## Validation

- changed YAML parses successfully
- `git diff --check` passes